### PR TITLE
Updated thrift version (0.7 to 0.9.2)

### DIFF
--- a/flume/pom.xml
+++ b/flume/pom.xml
@@ -16,6 +16,16 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.6.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>0.9.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.9.5</version>

--- a/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/hive/HiveClient.java
+++ b/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/hive/HiveClient.java
@@ -73,7 +73,7 @@ public class HiveClient {
             
             // execute the query
             rs = stmt.executeQuery(query);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             logger.error("Runtime error (The Hive table cannot be created. Hive query='" + query + "'. Details="
                     + e.getMessage() + ")");
             res = false;


### PR DESCRIPTION
Fix problem with method not found error at `HiveClient.java`. `TProtocol.getSchema()` does not exists in libthrift 0.7 so you need version 0.9 (I updated pom.xml to 0.9.2). As a consequence, you need to update also slf4j-api to 1.6.1.