### PR TITLE
Bug/rpm update#329#330

### DIFF
--- a/flume/neore/README.md
+++ b/flume/neore/README.md
@@ -10,7 +10,7 @@ In order to build the RPM package, follow the following steps:
   ```
   You can see full options of script package.sh typing `./package.sh -h`
 
-Note: due to a bug in rpm generation ([issue #329](https://github.com/telefonicaid/fiware-connectors/issues/329)) all packages 
+**Note:** due to a bug in rpm generation ([issue #329](https://github.com/telefonicaid/fiware-connectors/issues/329)) all packages 
 that were built before 2015/03/05 and installed should be erased manually and install a new one build after 2015/03/05.
 
 The date of the building of the installed package can be viewed with `rpm -qi cygnus` and look into **Build Date** field:

--- a/flume/neore/README.md
+++ b/flume/neore/README.md
@@ -1,11 +1,33 @@
 In order to build the RPM package, follow the following steps:
 
-* Build the Cygnus .jar with dependencies with `mvn clean compile exec:exec assembly:single` (see Cygnus README.md
+* Build the Cygnus .jar with dependencies with `mvn clean compile exec:exec assembly:single` (see Cygnus [README.md](../README.md)
   for additional detail).
-* Run the package.sh script (inside the scripts/ directory) which, upon finalization, will generate the .rpm
-  file in the rpm/RPMS directory. You must specify the version number (matching with the one in the pom.xml
-  file) with the `-v`argument, e.g.:
-  
+* Run the `package.sh` script (inside the scripts/ directory) which, upon finalization, will generate the .rpm
+  file in the `rpm/RPMS` directory. You must specify the version number (matching with the one in the pom.xml
+  file) with the `-v` argument, e.g.:
+  ```
+  ./package.sh -v 0.3
+  ```
+  You can see full options of script package.sh typing `./package.sh -h`
+
+Note: due to a bug in rpm generation ([issue #329](https://github.com/telefonicaid/fiware-connectors/issues/329)) all packages 
+that were built before 2015/03/05 and installed should be erased manually and install a new one build after 2015/03/05.
+
+The date of the building of the installed package can be viewed with `rpm -qi cygnus` and look into **Build Date** field:
+
+```shell
+$ rpm -qi cygnus
+Name        : cygnus                       Relocations: (not relocatable)
+Version     : 0.6.0                             Vendor: Telefonica I+D
+Release     : 35.g26e07c4                   Build Date: Mon 16 Feb 2015 03:56:58 PM CET
+Install Date: Mon 16 Feb 2015 04:14:04 PM CET      Build Host: ci-iot-deven-01
+Group       : Applications/cygnus           Source RPM: cygnus-0.6.0-35.g26e07c4.src.rpm
+Size        : 107280119                        License: AGPLv3
+Signature   : (none)
+Summary     : Package for cygnus component
+Description :
+This connector is a (conceptual) derivative work of ngsi2cosmos, and implements
+a Flume-based connector for context data coming from Orion Context Broker.
 ```
-./package.sh -v 0.3
-```
+
+All packages build before 2015/03/05 should be erased and generated again.

--- a/flume/neore/rpm/SPECS/cygnus.spec
+++ b/flume/neore/rpm/SPECS/cygnus.spec
@@ -107,6 +107,12 @@ mkdir -p %{buildroot}/${_log_dir}
 mkdir -p %{buildroot}/etc/cron.d
 # Create /etc/logrotate.d directory
 mkdir -p %{buildroot}/etc/logrotate.d
+# create /etc/cygnus
+mkdir -p %{buildroot}/etc/%{_project_name}
+# create /etc/init.d
+mkdir -p %{buildroot}/etc/init.d
+# create /usr/bin
+mkdir -p %{buildroot}/usr/bin
 
 cp -R %{_builddir}/usr/cygnus/*                       %{_build_root_project}
 cp %{_builddir}/init.d/%{_service_name}               %{_build_root_project}/init.d/%{_service_name}
@@ -114,24 +120,14 @@ cp %{_builddir}/config/*                              %{_build_root_project}/con
 cp %{_builddir}/cron.d/cleanup_old_cygnus_logfiles    %{buildroot}/etc/cron.d
 cp %{_builddir}/logrotate.d/logrotate-cygnus-daily    %{buildroot}/etc/logrotate.d
 
+ln -s %{_project_install_dir}/init.d/%{_service_name}  %{buildroot}/etc/init.d/%{_service_name}
+ln -s %{_project_install_dir}/conf                     %{buildroot}/etc/%{_project_name}/conf
+ln -s %{_project_install_dir}/bin/flume-ng             %{buildroot}/usr/bin/flume-ng
+
 # -------------------------------------------------------------------------------------------- #
 # post-install section:
 # -------------------------------------------------------------------------------------------- #
 %post
-
-echo "[INFO] Configuring application"
-mkdir -p /etc/%{_project_name}
-
-echo "[INFO] Creating links if not exists "
-if [[ ! -L %{_project_install_dir}/init.d/%{_service_name} /etc/init.d/%{_service_name} ]]; then
-	ln -s %{_project_install_dir}/init.d/%{_service_name} /etc/init.d/%{_service_name}
-fi
-if [[ ! -L %{_project_install_dir}/conf /etc/%{_project_name} ]]; then
-	ln -s %{_project_install_dir}/conf /etc/%{_project_name}
-fi
-if [[ ! -L %{_project_install_dir}/bin/flume-ng /usr/bin/flume-ng ]]; then
-	ln -s %{_project_install_dir}/bin/flume-ng /usr/bin/flume-ng
-fi
 
 #Logs
 echo "[INFO] Creating log directory"
@@ -147,6 +143,9 @@ echo "Done"
 # pre-uninstall section:
 # -------------------------------------------------------------------------------------------- #
 %preun
+
+/sbin/service %{_service_name} stop
+
 
 # -------------------------------------------------------------------------------------------- #
 # post-uninstall section:
@@ -166,7 +165,9 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(755,%{_project_user},%{_project_user},755)
 %attr(0644, root, root) /etc/cron.d/cleanup_old_cygnus_logfiles
 %attr(0644, root, root) /etc/logrotate.d/logrotate-cygnus-daily
-%attr(0644, cygnus, cygnus) /usr/cygnus/conf/*
+%attr(0777, root, root) /etc/cygnus/conf
+%attr(0777, root, root) /etc/init.d/cygnus
+%attr(0777, root, root) /usr/bin/flume-ng
 
 %{_project_install_dir}
 /var/run/%{_project_name}

--- a/flume/neore/rpm/SPECS/cygnus.spec
+++ b/flume/neore/rpm/SPECS/cygnus.spec
@@ -132,9 +132,6 @@ chmod g+s %{_log_dir}
 setfacl -d -m g::rwx %{_log_dir}
 setfacl -d -m o::rx %{_log_dir}
 
-echo "[INFO] Configuring application service"
-# FIXME! Not supported
-# chkconfig --add %{_service_name}
 echo "Done"
 
 # -------------------------------------------------------------------------------------------- #
@@ -142,31 +139,13 @@ echo "Done"
 # -------------------------------------------------------------------------------------------- #
 %preun
 
-echo "[INFO] Uninstall the %{_project_name}"
-/etc/init.d/%{_service_name} stop
-/sbin/chkconfig --del %{_service_name}
-
-echo "[INFO] Deleting links"
-rm /etc/init.d/%{_service_name} \
-/etc/%{_project_name}/flume.conf \
-/usr/bin/flume-ng
-
-echo "[INFO] Removing application log files"
-[ -d %{_log_dir} ] && rm -rfv %{_log_dir} &> /dev/null
-
-echo "[INFO] Deleting the %{_project_name} folder"
-[ -d %{_project_install_dir} ] && rm -rfv %{_project_install_dir} &> /dev/null
-
-echo "[INFO] Deleting the %{_project_user} user"
-sudo userdel %{_project_user}
-
-echo "Done"
-
 # -------------------------------------------------------------------------------------------- #
 # post-uninstall section:
 # clean section:
 # -------------------------------------------------------------------------------------------- #
 %postun
+
+
 %clean
 rm -rf $RPM_BUILD_ROOT
 

--- a/flume/neore/rpm/SPECS/cygnus.spec
+++ b/flume/neore/rpm/SPECS/cygnus.spec
@@ -37,7 +37,7 @@ a Flume-based connector for context data coming from Orion Context Broker.
 %define _service_name cygnus
 
 # improve package speed avoiding jar repack
-define __jar_repack %{nil}
+%define __jar_repack %{nil}
 
 # System folders
 # _sourcedir =${topdir}/SOURCES

--- a/flume/neore/rpm/SPECS/cygnus.spec
+++ b/flume/neore/rpm/SPECS/cygnus.spec
@@ -36,6 +36,9 @@ a Flume-based connector for context data coming from Orion Context Broker.
 %define _project_user cygnus
 %define _service_name cygnus
 
+# improve package speed avoiding jar repack
+define __jar_repack %{nil}
+
 # System folders
 # _sourcedir =${topdir}/SOURCES
 %define _srcdir %{_sourcedir}/../../../

--- a/flume/neore/rpm/SPECS/cygnus.spec
+++ b/flume/neore/rpm/SPECS/cygnus.spec
@@ -74,7 +74,6 @@ cp -R %{_sourcedir}/* %{_builddir}
 %build
 # Read from BUILD, write into BUILD
 
-echo "[INFO] Building..."
 
 # -------------------------------------------------------------------------------------------- #
 # pre-install section:
@@ -119,10 +118,17 @@ cp %{_builddir}/logrotate.d/logrotate-cygnus-daily    %{buildroot}/etc/logrotate
 
 echo "[INFO] Configuring application"
 mkdir -p /etc/%{_project_name}
-echo "[INFO] Creating links"
-ln -s %{_project_install_dir}/init.d/%{_service_name} /etc/init.d/%{_service_name}
-ln -s %{_project_install_dir}/conf /etc/%{_project_name}
-ln -s %{_project_install_dir}/bin/flume-ng /usr/bin/flume-ng
+
+echo "[INFO] Creating links if not exists "
+if [[ ! -L %{_project_install_dir}/init.d/%{_service_name} /etc/init.d/%{_service_name} ]]; then
+	ln -s %{_project_install_dir}/init.d/%{_service_name} /etc/init.d/%{_service_name}
+fi
+if [[ ! -L %{_project_install_dir}/conf /etc/%{_project_name} ]]; then
+	ln -s %{_project_install_dir}/conf /etc/%{_project_name}
+fi
+if [[ ! -L %{_project_install_dir}/bin/flume-ng /usr/bin/flume-ng ]]; then
+	ln -s %{_project_install_dir}/bin/flume-ng /usr/bin/flume-ng
+fi
 
 #Logs
 echo "[INFO] Creating log directory"

--- a/flume/neore/scripts/package.sh
+++ b/flume/neore/scripts/package.sh
@@ -24,17 +24,18 @@ function download_flume(){
 	# download form artifactory and unzip it into ${RPM_BASE_DIR}
 	_logStage "######## Preparing the apache-flume component... ########"
 
+	local ARTIFACT_FLUME_URL=${1}
+	local FLUME_TAR=${2}
+
 	local TMP_DIR="tmp_deleteme"
 	mkdir -p ${TMP_DIR}
 	pushd ${TMP_DIR} &> /dev/null
-	local FLUME_TAR=${2}
 	#remove .tar.gz so twice is executed
 	local FLUME_WO_TAR=${FLUME_TAR%.*}
 	FLUME_WO_TAR=${FLUME_WO_TAR%.*}
 
 
 	_log "#### The version of the component is (${FLUME_TAR}) ####"
-	local ARTIFACT_FLUME_URL=${1}
 	_log "#### Downloading apache-flume: ${FLUME_TAR}... ####"
 	curl -s -o ${FLUME_TAR} ${ARTIFACT_FLUME_URL}/${FLUME_TAR}
 	if [[ $? -ne 0 ]]; then
@@ -218,7 +219,7 @@ if [[ -d "${RPM_BASE_DIR}" ]]; then
 
 	clean_up_previous_builds 
 
-	download_flume ARTIFACT_URL ARTIFACT_NAME
+	download_flume ${ARTIFACT_URL} ${ARTIFACT_NAME}
 	[[ $? -ne 0 ]] && exit 1
 
     copy_cygnus_startup_script


### PR DESCRIPTION
This PR is about issues https://github.com/telefonicaid/fiware-connectors/issues/329 and  https://github.com/telefonicaid/fiware-connectors/issues/330.

Moreover an improvement has been made to make RPM package more fast letting the user to download flume form other repo using options -u and -a in package script.

Just execute flume/neore/script/package.sh -h to view all options

Note that you need to remove previous Cygnus package before install the new package. Then you can upgrade it without removing previous version