### PR TITLE
feature/320_die_if_no_logs

### DIFF
--- a/flume/CHANGES_NEXT_RELEASE
+++ b/flume/CHANGES_NEXT_RELEASE
@@ -4,3 +4,5 @@
 * Bug fixing: error in configuration template (cygnusagent.sinks.hdfs-sink.krb5_auth.krb5_login_conf_file) (#308)
 * Encourage the usage of FQDNs regarding HDFS namenodes when using Kerberos (#309)
 * Fixed OrionMySQLSink logger (now it logs as OrionMySQLSink, not as OrionHDFSSink) (#321)
+* Ordered death of Cygnus if the logging system fails or it is stoped (#320)
+* Management interface port is not opened twice anymore (#302)

--- a/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/channels/CygnusChannel.java
+++ b/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/channels/CygnusChannel.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-connectors (FI-WARE project).
+ *
+ * fiware-connectors is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-connectors is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-connectors. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package es.tid.fiware.fiwareconnectors.cygnus.channels;
+
+/**
+ * Interface that all the Cygnus proprietary channels must implement. It defines common methods for all of them, such
+ * as getNumEvents().
+ * 
+ * @author frb
+ */
+public interface CygnusChannel {
+    
+    /**
+     * Gets the number of events within the channel.
+     * @return The number of events within the channel.
+     */
+    int getNumEvents();
+    
+    /**
+     * Rollbacks the number of events when a transaction is rollbacked as well. This method is necessary beacuse when
+     * a transaction is rollbacked the "put" method is not used but some kind of internal re-linking is done at the
+     * chanel; thus, the number of events is not increased, which must be deliberatedly done by issuing this method.
+     */
+    void rollback();
+    
+} // CygnusChannel

--- a/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/channels/CygnusFileChannel.java
+++ b/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/channels/CygnusFileChannel.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-connectors (FI-WARE project).
+ *
+ * fiware-connectors is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-connectors is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-connectors. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package es.tid.fiware.fiwareconnectors.cygnus.channels;
+
+import org.apache.flume.Event;
+import org.apache.flume.channel.file.FileChannel;
+
+/**
+ * CygnusFileChannel is an extension of Flume's FileChannel. Basically, it is the same channel but having methods
+ * for sizing control.
+ * 
+ * @author frb
+ */
+public class CygnusFileChannel extends FileChannel implements CygnusChannel {
+    
+    private int numEvents;
+    
+    @Override
+    protected void initialize() {
+        super.initialize();
+        numEvents = 0;
+    } // initialize
+    
+    @Override
+    public void put(Event event) {
+        super.put(event);
+        numEvents++;
+    } // put
+    
+    @Override
+    public Event take() {
+        numEvents--;
+        return super.take();
+    } // take
+    
+    @Override
+    public int getNumEvents() {
+        return numEvents;
+    } // getNumEvents
+    
+    @Override
+    public void rollback() {
+        numEvents++;
+    } // rollback
+    
+} // CygnusFileChannel

--- a/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/channels/CygnusMemoryChannel.java
+++ b/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/channels/CygnusMemoryChannel.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-connectors (FI-WARE project).
+ *
+ * fiware-connectors is free software: you can redistribute it and/or modify it under the terms of the GNU Affero
+ * General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ * fiware-connectors is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with fiware-connectors. If not, see
+ * http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License please contact with iot_support at tid dot es
+ */
+package es.tid.fiware.fiwareconnectors.cygnus.channels;
+
+import org.apache.flume.Event;
+import org.apache.flume.channel.MemoryChannel;
+
+/**
+ * CygnusMemoryChannel is an extension of Flume's MemoryChannel. Basically, it is the same channel but having methods
+ * for sizing control.
+ * 
+ * @author frb
+ */
+public class CygnusMemoryChannel extends MemoryChannel implements CygnusChannel {
+    
+    private int numEvents;
+    
+    @Override
+    protected void initialize() {
+        super.initialize();
+        numEvents = 0;
+    } // initialize
+    
+    @Override
+    public void put(Event event) {
+        super.put(event);
+        numEvents++;
+    } // put
+    
+    @Override
+    public Event take() {
+        Event event = super.take();
+        
+        if (event != null) {
+            numEvents--;
+        } // if
+        
+        return event;
+    } // take
+    
+    @Override
+    public int getNumEvents() {
+        return numEvents;
+    } // getNumEvents
+    
+    @Override
+    public void rollback() {
+        numEvents++;
+    } // rollback
+    
+} // CygnusMemoryChannel

--- a/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/log/CygnusLogger.java
+++ b/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/log/CygnusLogger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2015 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of fiware-connectors (FI-WARE project).
  *
@@ -21,17 +21,25 @@ package es.tid.fiware.fiwareconnectors.cygnus.log;
 import org.apache.log4j.Logger;
 
 /**
- *
+ * Cygnus logger basically extends log4j logger. It adds, nevertheless, certain useful features such as:
+ *    - Printing the name of the component trying to log.
+ *    - Checking for the logging system availability.
+ *    - Ordering the shutdown of Cygnus if the above check fails.
+ * 
  * @author frb
  */
 public class CygnusLogger extends Logger {
     
+    private boolean shutdown;
+    
     /**
      * Constructor.
      * @param name
+     * @param shutdown
      */
-    public CygnusLogger(String name) {
+    public CygnusLogger(String name, boolean shutdown) {
         super(name);
+        this.shutdown = shutdown;
     } // CygnusLogger
     
     /**
@@ -40,7 +48,14 @@ public class CygnusLogger extends Logger {
      * @param message
      */
     public void info(String componentName, String message) {
-        info("[" + componentName + "] " + message);
+        try {
+            info("[" + componentName + "] " + message);
+        } catch (Exception e) {
+            if (shutdown) {
+                System.err.println("A problem with the logging system was found... shutting down Cygnus right now!");
+                System.exit(-1);
+            } // if
+        } // catch
     } // info
     
     /**
@@ -49,7 +64,14 @@ public class CygnusLogger extends Logger {
      * @param message
      */
     public void error(String componentName, String message) {
-        error("[" + componentName + "] " + message);
+        try {
+            error("[" + componentName + "] " + message);
+        } catch (Exception e) {
+            if (shutdown) {
+                System.err.println("A problem with the logging system was found... shutting down Cygnus right now!");
+                System.exit(-1);
+            } // if
+        } // catch
     } // error
     
     /**
@@ -58,7 +80,14 @@ public class CygnusLogger extends Logger {
      * @param message
      */
     public void fatal(String componentName, String message) {
-        fatal("[" + componentName + "] " + message);
+        try {
+            fatal("[" + componentName + "] " + message);
+        } catch (Exception e) {
+            if (shutdown) {
+                System.err.println("A problem with the logging system was found... shutting down Cygnus right now!");
+                System.exit(-1);
+            } // if
+        } // catch
     } // fatal
     
     /**
@@ -67,7 +96,14 @@ public class CygnusLogger extends Logger {
      * @param message
      */
     public void warn(String componentName, String message) {
-        warn("[" + componentName + "] " + message);
+        try {
+            warn("[" + componentName + "] " + message);
+        } catch (Exception e) {
+            if (shutdown) {
+                System.err.println("A problem with the logging system was found... shutting down Cygnus right now!");
+                System.exit(-1);
+            } // if
+        } // catch
     } // warn
     
     /**
@@ -76,7 +112,14 @@ public class CygnusLogger extends Logger {
      * @param message
      */
     public void debug(String componentName, String message) {
-        debug("[" + componentName + "] " + message);
+        try {
+            debug("[" + componentName + "] " + message);
+        } catch (Exception e) {
+            if (shutdown) {
+                System.err.println("A problem with the logging system was found... shutting down Cygnus right now!");
+                System.exit(-1);
+            } // if
+        } // catch
     } // debug
     
 } // CygnusLogger

--- a/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/nodes/CygnusApplication.java
+++ b/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/nodes/CygnusApplication.java
@@ -53,10 +53,17 @@ import org.apache.flume.node.PropertiesFileConfigurationProvider;
 import org.apache.log4j.Logger;
 
 /**
- * CygnusApplication class is basically a modification of the alredy existent org.apache.flume.node.Application class.
- * At a first attempt we tried to extend the Application class, but access to certain private variables such as the
- * supervisor were needed, thus finally CygnusApplication class had to be created from the scratch, highly inspired by
- * the original Application class.
+ * CygnusApplication is an extension of the already existing org.apache.flume.node.Application. CygnusApplication
+ * is closed in an ordered way, first the sources in order to no not receiving further notifications, then the
+ * application waits until the channels are emptied by the sinks, finally the sinks are closed.
+ * 
+ * Java Reflection has been used in order to access the LifecycleSupervisor supervisor private variable since this
+ * object allows to effectively stop the Cygnus agent components (if directly stoped from the components referecnes
+ * then the lifecycle supervisor starts them again).
+ * 
+ * Cygnus agent components references are obtained only once, at handleConfigurationEvent method since it already
+ * receives as an argument a MaterializedConfiguration object (if a new MaterializedConfiguration is gotten then new
+ * instances of the components are started).
  * 
  * @author frb
  */

--- a/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/sinks/OrionSink.java
+++ b/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/sinks/OrionSink.java
@@ -19,6 +19,7 @@
 package es.tid.fiware.fiwareconnectors.cygnus.sinks;
 
 import com.google.gson.Gson;
+import es.tid.fiware.fiwareconnectors.cygnus.channels.CygnusChannel;
 import es.tid.fiware.fiwareconnectors.cygnus.containers.NotifyContextRequest;
 import es.tid.fiware.fiwareconnectors.cygnus.containers.NotifyContextRequestSAXHandler;
 import es.tid.fiware.fiwareconnectors.cygnus.errors.CygnusBadConfiguration;
@@ -145,6 +146,7 @@ public abstract class OrionSink extends AbstractSink implements Configurable {
                     String newTTL = new Integer(ttl - 1).toString();
                     event.getHeaders().put(Constants.HEADER_TTL, newTTL);
                     txn.rollback();
+                    ((CygnusChannel) ch).rollback();
                     status = Status.BACKOFF;
                     logger.info("An event was put again in the channel (id=" + event.hashCode() + ", ttl=" + newTTL
                             + ")");


### PR DESCRIPTION
* Implements issue https://github.com/telefonicaid/fiware-connectors/issues/320
* Fixes issue https://github.com/telefonicaid/fiware-connectors/issues/302
* 100% unit tests passed
```
Results :
Tests run: 45, Failures: 0, Errors: 0, Skipped: 0
```
* (Unofficial) e2e tests passed (emulating a persistence error, ttl=2)
```
Starting an ordered shutdown of Cygnus
Stopping sources
Stopping http-source (lyfecycle state=START)
There are 1 events within hdfs-channel, Cygnus cannnot shutdown yet
Waiting 5 seconds
There are 1 events within hdfs-channel, Cygnus cannnot shutdown yet
Waiting 5 seconds
There are 1 events within hdfs-channel, Cygnus cannnot shutdown yet
Waiting 5 seconds
All the channels are empty
Stopping channels
Stopping hdfs-channel (lyfecycle state=START)
Stopping sinks
Stopping hdfs-sink (lyfecycle state=START)
```
* Ths PR must be twined into develop
* Assignee: @fgalan , but LGTM from @gtorodelvalle is also required