### PR TITLE
hardening/334_polling_time

### DIFF
--- a/flume/CHANGES_NEXT_RELEASE
+++ b/flume/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+* Added a polling interval parameter for reloading the Flume configuration (#334)

--- a/flume/README.md
+++ b/flume/README.md
@@ -275,6 +275,8 @@ AGENT_NAME=cygnusagent
 LOGFILE_NAME=cygnus.log
 # Administration port. Must be unique per instance
 ADMIN_PORT=8081
+# Polling interval for the configuration reloading
+POLLING_INTERVAL=30
 ```
 
 ###`agent_<id>.conf`
@@ -460,11 +462,11 @@ Cygnus implements its own startup script, `cygnus-flume-ng` which replaces the s
 
 In foreground (with logging):
 
-    $ APACHE_FLUME_HOME/bin/cygnus-flume-ng agent --conf APACHE_FLUME_HOME/conf -f APACHE_FLUME_HOME/conf/cygnus.conf -n cygnusagent -Dflume.root.logger=INFO,console [-p <mgmt-if-port>]
+    $ APACHE_FLUME_HOME/bin/cygnus-flume-ng agent --conf APACHE_FLUME_HOME/conf -f APACHE_FLUME_HOME/conf/cygnus.conf -n cygnusagent -Dflume.root.logger=INFO,console [-p <mgmt-if-port>] [-t <polling-interval>]
 
 In background:
 
-    $ nohup APACHE_FLUME_HOME/bin/cygnus-flume-ng agent --conf APACHE_FLUME_HOME/conf -f APACHE_FLUME_HOME/conf/cygnus.conf -n cygnusagent -Dflume.root.logger=INFO,LOGFILE [-p <mgmt-if-port>] &
+    $ nohup APACHE_FLUME_HOME/bin/cygnus-flume-ng agent --conf APACHE_FLUME_HOME/conf -f APACHE_FLUME_HOME/conf/cygnus.conf -n cygnusagent -Dflume.root.logger=INFO,LOGFILE [-p <mgmt-if-port>] [-t <polling-interval>] &
 
 The parameters used in these commands are:
 
@@ -474,6 +476,7 @@ The parameters used in these commands are:
 * `-n` (or `--name`). The name of the Flume agent to be run.
 * `-Dflume.root.logger`. Changes the logging level and the logging appender for log4j.
 * `-p` (or `--mgmt-if-port`). Configures the listening port for the Management Interface. If not configured, the default value is used, `8081`.
+* `-t` (or `--polling-interval`). Configures the polling interval when the configuration is periodically reloaded. If not configured, the default value is used, `30`.
 
 ## Orion subscription
 

--- a/flume/README.md
+++ b/flume/README.md
@@ -275,7 +275,7 @@ AGENT_NAME=cygnusagent
 LOGFILE_NAME=cygnus.log
 # Administration port. Must be unique per instance
 ADMIN_PORT=8081
-# Polling interval for the configuration reloading
+# Polling interval (seconds) for the configuration reloading
 POLLING_INTERVAL=30
 ```
 
@@ -476,7 +476,7 @@ The parameters used in these commands are:
 * `-n` (or `--name`). The name of the Flume agent to be run.
 * `-Dflume.root.logger`. Changes the logging level and the logging appender for log4j.
 * `-p` (or `--mgmt-if-port`). Configures the listening port for the Management Interface. If not configured, the default value is used, `8081`.
-* `-t` (or `--polling-interval`). Configures the polling interval when the configuration is periodically reloaded. If not configured, the default value is used, `30`.
+* `-t` (or `--polling-interval`). Configures the polling interval (seconds) when the configuration is periodically reloaded. If not configured, the default value is used, `30`.
 
 ## Orion subscription
 

--- a/flume/conf/cygnus_instance.conf.template
+++ b/flume/conf/cygnus_instance.conf.template
@@ -39,5 +39,5 @@ LOGFILE_NAME=cygnus.log
 # Administration port. Must be unique per instance
 ADMIN_PORT=8081
 
-# Polling interval for the configuration reloading
+# Polling interval (seconds) for the configuration reloading
 POLLING_INTERVAL=30

--- a/flume/conf/cygnus_instance.conf.template
+++ b/flume/conf/cygnus_instance.conf.template
@@ -38,3 +38,6 @@ LOGFILE_NAME=cygnus.log
 
 # Administration port. Must be unique per instance
 ADMIN_PORT=8081
+
+# Polling interval for the configuration reloading
+POLLING_INTERVAL=30

--- a/flume/neore/README.md
+++ b/flume/neore/README.md
@@ -11,6 +11,7 @@ In order to build the RPM package, follow the following steps:
   You can see full options of script package.sh typing `./package.sh -h`
 
 When a package is built it introduces three features in Cygnus SW:
+
 * Daily log rotation: use logrotate tool to perform this operation. View 
   [logrotate config file](rpm/SOURCES/logrotate.d/logrotate-cygnus-daily) for more info
 * Automatic deletion of files older than 30 days programmed in cron:

--- a/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/nodes/CygnusApplication.java
+++ b/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/nodes/CygnusApplication.java
@@ -50,6 +50,9 @@ public class CygnusApplication extends Application {
     private static Logger logger;
     private int mgmtIfPort;
     private JettyServer server;
+    private static final int DEF_MGMT_IF_PORT = 8081;
+    private static final int DEF_POLLING_INTERVAL = 30;
+    
     
     /**
      * Constructor.
@@ -132,16 +135,16 @@ public class CygnusApplication extends Application {
                 return;
             } // if
             
-            int mgmtIfPort = 8081; // default value
+            int mgmtIfPort = DEF_MGMT_IF_PORT;
             
             if (commandLine.hasOption('p')) {
                 mgmtIfPort = new Integer(commandLine.getOptionValue('p')).intValue();
             } // if
             
-            int pollingTime = 30; // default value
+            int pollingInterval = DEF_POLLING_INTERVAL;
             
             if (commandLine.hasOption('t')) {
-                pollingTime = new Integer(commandLine.getOptionValue('t'));
+                pollingInterval = new Integer(commandLine.getOptionValue('t'));
             } // if
             
             // the following is to ensure that by default the agent will fail on startup if the file does not exist
@@ -168,7 +171,7 @@ public class CygnusApplication extends Application {
                 EventBus eventBus = new EventBus(agentName + "-event-bus");
                 PollingPropertiesFileConfigurationProvider configurationProvider =
                         new PollingPropertiesFileConfigurationProvider(agentName, configurationFile, eventBus,
-                                pollingTime);
+                                pollingInterval);
                 components.add(configurationProvider);
                 application = new CygnusApplication(components, mgmtIfPort);
                 eventBus.register(application);

--- a/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/nodes/CygnusApplication.java
+++ b/flume/src/main/java/es/tid/fiware/fiwareconnectors/cygnus/nodes/CygnusApplication.java
@@ -106,13 +106,17 @@ public class CygnusApplication extends Application {
             option.setRequired(true);
             options.addOption(option);
 
-            option = new Option(null, "no-reload-conf", false, "do not reload " + "conf file if changed");
+            option = new Option(null, "no-reload-conf", false, "do not reload conf file if changed");
             options.addOption(option);
 
             option = new Option("h", "help", false, "display help text");
             options.addOption(option);
             
             option = new Option("p", "mgmt-if-port", true, "the management interface port");
+            option.setRequired(false);
+            options.addOption(option);
+            
+            option = new Option("t", "polling-interval", true, "polling interval");
             option.setRequired(false);
             options.addOption(option);
 
@@ -132,6 +136,12 @@ public class CygnusApplication extends Application {
             
             if (commandLine.hasOption('p')) {
                 mgmtIfPort = new Integer(commandLine.getOptionValue('p')).intValue();
+            } // if
+            
+            int pollingTime = 30; // default value
+            
+            if (commandLine.hasOption('t')) {
+                pollingTime = new Integer(commandLine.getOptionValue('t'));
             } // if
             
             // the following is to ensure that by default the agent will fail on startup if the file does not exist
@@ -157,7 +167,8 @@ public class CygnusApplication extends Application {
             if (reload) {
                 EventBus eventBus = new EventBus(agentName + "-event-bus");
                 PollingPropertiesFileConfigurationProvider configurationProvider =
-                        new PollingPropertiesFileConfigurationProvider(agentName, configurationFile, eventBus, 30);
+                        new PollingPropertiesFileConfigurationProvider(agentName, configurationFile, eventBus,
+                                pollingTime);
                 components.add(configurationProvider);
                 application = new CygnusApplication(components, mgmtIfPort);
                 eventBus.register(application);


### PR DESCRIPTION
* Implements issue https://github.com/telefonicaid/fiware-connectors/issues/334
* 100% unit tests passed

```
Results :

Tests run: 45, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 10.976s
[INFO] Finished at: Tue Mar 17 11:52:37 CET 2015
[INFO] Final Memory: 7M/81M
[INFO] ------------------------------------------------------------------------
```

* (unofficial) e2e tests passed:

Polling interval = 10

```
2015-03-17T11:56:24.259CET | lvl=DEBUG | trans= | function=run | comp=Cygnus | msg=org.apache.flume.node.PollingPropertiesFileConfigurationProvider[126] : Checking file:/Applications/apache-flume-1.4.0-bin/conf/cygnus.conf for changes
2015-03-17T11:56:34.263CET | lvl=DEBUG | trans= | function=run | comp=Cygnus | msg=org.apache.flume.node.PollingPropertiesFileConfigurationProvider[126] : Checking file:/Applications/apache-flume-1.4.0-bin/conf/cygnus.conf for changes
2015-03-17T11:56:44.265CET | lvl=DEBUG | trans= | function=run | comp=Cygnus | msg=org.apache.flume.node.PollingPropertiesFileConfigurationProvider[126] : Checking file:/Applications/apache-flume-1.4.0-bin/conf/cygnus.conf for changes
2015-03-17T11:56:54.270CET | lvl=DEBUG | trans= | function=run | comp=Cygnus | msg=org.apache.flume.node.PollingPropertiesFileConfigurationProvider[126] : Checking file:/Applications/apache-flume-1.4.0-bin/conf/cygnus.conf for changes
2015-03-17T11:57:04.271CET | lvl=DEBUG | trans= | function=run | comp=Cygnus | msg=org.apache.flume.node.PollingPropertiesFileConfigurationProvider[126] : Checking file:/Applications/apache-flume-1.4.0-bin/conf/cygnus.conf for changes
2015-03-17T11:57:14.273CET | lvl=DEBUG | trans= | function=run | comp=Cygnus | msg=org.apache.flume.node.PollingPropertiesFileConfigurationProvider[126] : Checking file:/Applications/apache-flume-1.4.0-bin/conf/cygnus.conf for changes
```

Polling interval = 60

```
2015-03-17T11:59:32.535CET | lvl=DEBUG | trans= | function=run | comp=Cygnus | msg=org.apache.flume.node.PollingPropertiesFileConfigurationProvider[126] : Checking file:/Applications/apache-flume-1.4.0-bin/conf/cygnus.conf for changes
2015-03-17T12:00:32.537CET | lvl=DEBUG | trans= | function=run | comp=Cygnus | msg=org.apache.flume.node.PollingPropertiesFileConfigurationProvider[126] : Checking file:/Applications/apache-flume-1.4.0-bin/conf/cygnus.conf for changes
2015-03-17T12:01:32.541CET | lvl=DEBUG | trans= | function=run | comp=Cygnus | msg=org.apache.flume.node.PollingPropertiesFileConfigurationProvider[126] : Checking file:/Applications/apache-flume-1.4.0-bin/conf/cygnus.conf for changes
```

* Assignee: @vgarciag , but LGTM from @fgalan and @gtorodelvalle is also required
