### PR TITLE
bug/384_flume_conf_file

### DIFF
--- a/flume/CHANGES_NEXT_RELEASE
+++ b/flume/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 * Added a polling interval parameter for reloading the Flume configuration (#334)
+* Bug fix, flume-conf.properties.template file from Apache Flume is not copied anymore to Cygnus folder (#348)

--- a/flume/conf/README.md
+++ b/flume/conf/README.md
@@ -4,26 +4,26 @@ From version 0.6.0 Cygnus is able to start multiple instances by renaming and co
 templates files of this directory.
 
 There are two types of configuration template files:
-1- Those applying to all the Cygnus instances; thus, they are unique.
-2- Those applying specifically to one Cygnus instance; thus, there is a configuration file per each instance.
 
-## 1- Unique files for all instances
+* Those applying to all the Cygnus instances; thus, they are unique.
+* Those applying specifically to one Cygnus instance; thus, there is a configuration file per each instance.
 
-For them is necessary rename (or better copy) it without `.template` extension.
-These files are: `log4j.properties.template`, `krb5.conf.template` and `matching_table.conf.template`
+## Unique files for all instances
+
+For them is necessary rename (or better copy) it without `.template` extension. These files are: `log4j.properties.template`, `flume-env.sh.template`, `krb5.conf.template` and `matching_table.conf.template`
 
 ```bash
 cp /usr/cygnus/conf/log4j.properties.template /usr/cygnus/conf/log4j.properties
+cp /usr/cygnus/conf/flume-env.sh.template /usr/cygnus/conf/flume-env.sh
 cp /usr/cygnus/conf/krb5.conf.template /usr/cygnus/conf/krb5.conf
 cp /usr/cygnus/conf/matching_table.conf.template /usr/cygnus/conf/matching_table.conf
 ```
 
 Then each file can be edited in order to change the configuration that will affect to all intances of Cygnus.
 
-## 2- Files for each instance
+## Files for each instance
 
-The other files are `cygnus.conf.template` and `flume.conf.template`. These files should be copied 
-for each intantance of Cygnus that want to run.
+The other files are `cygnus.conf.template` and `flume.conf.template`. These files should be copied for each intantance of Cygnus that want to run.
 
 Example:
 ```bash
@@ -31,8 +31,7 @@ cp /usr/cygnus/conf/cygnus_instance.conf.template  /usr/cygnus/conf/cygnus_insta
 cp /usr/cygnus/conf/agent.conf.template /usr/cygnus/conf/agent_example1.conf
 ```
 
-It is very important that there are one, or more, file that begins with `cygnus_instance_.*` because
-the service script try to start a Cygnus instance per each file prefixed as previously mentioned within
+It is very important that there are one, or more, file that begins with `cygnus_instance_.*` because the service script try to start a Cygnus instance per each file prefixed as previously mentioned within
  `/usr/cygnus/conf`.
 
 Then edit first `cygnus_instance_example1.conf` changing values of:
@@ -41,15 +40,13 @@ Then edit first `cygnus_instance_example1.conf` changing values of:
 CONFIG_FILE=/usr/cygnus/conf/agent_example1.conf
 LOGFILE_NAME=cygnus_example1.log
 ADMIN_PORT=8081
+POLLING_INTERVAL=30
 ```
 
-Next edit `/usr/cygnus/agent_example1.conf` changing value of listening port to be unique.
+Next edit `/usr/cygnus/agent_example1.conf` changing the value of listening port to be unique.
 
 ```bash
 cygnusagent.sources.http-source.port = 5050
 ```
 
-Teh configuration explained above is for basic configuration of Cygnus instance to run. More detailed configuration 
-should be required, such as [Cygnus configuration](https://github.com/telefonicaid/fiware-connectors/tree/master/flume#cygnus-configuration "Cygnus fine configuration"), 
-fine configuration of [log4j](https://github.com/telefonicaid/fiware-connectors/tree/master/flume#logs "Log4j detailed configuration"), 
-etc. 
+The configuration explained above is for basic configuration of Cygnus instance to run. More detailed configuration should be required, such as [Cygnus configuration](https://github.com/telefonicaid/fiware-connectors/tree/master/flume#cygnus-configuration "Cygnus fine configuration"), fine configuration of [log4j](https://github.com/telefonicaid/fiware-connectors/tree/master/flume#logs "Log4j detailed configuration"), etc. 

--- a/flume/conf/README.md
+++ b/flume/conf/README.md
@@ -23,7 +23,7 @@ Then each file can be edited in order to change the configuration that will affe
 
 ## Files for each instance
 
-The other files are `cygnus.conf.template` and `flume.conf.template`. These files should be copied for each intantance of Cygnus that want to run.
+The other files are `cygnus.conf.template` and `flume.conf.template`. These files should be copied for each instance of Cygnus wanted to be run.
 
 Example:
 ```bash

--- a/flume/neore/scripts/package.sh
+++ b/flume/neore/scripts/package.sh
@@ -21,93 +21,92 @@
 #################################################
 
 function download_flume(){
-	# download form artifactory and unzip it into ${RPM_BASE_DIR}
-	_logStage "######## Preparing the apache-flume component... ########"
+    # download form artifactory and unzip it into ${RPM_BASE_DIR}
+    _logStage "######## Preparing the apache-flume component... ########"
 
-	local ARTIFACT_FLUME_URL=${1}
-	local FLUME_TAR=${2}
+    local ARTIFACT_FLUME_URL=${1}
+    local FLUME_TAR=${2}
 
-	local TMP_DIR="tmp_deleteme"
-	mkdir -p ${TMP_DIR}
-	pushd ${TMP_DIR} &> /dev/null
-	#remove .tar.gz so twice is executed
-	local FLUME_WO_TAR=${FLUME_TAR%.*}
-	FLUME_WO_TAR=${FLUME_WO_TAR%.*}
+    local TMP_DIR="tmp_deleteme"
+    mkdir -p ${TMP_DIR}
+    pushd ${TMP_DIR} &> /dev/null
+    #remove .tar.gz so twice is executed
+    local FLUME_WO_TAR=${FLUME_TAR%.*}
+    FLUME_WO_TAR=${FLUME_WO_TAR%.*}
 
 
-	_log "#### The version of the component is (${FLUME_TAR}) ####"
-	_log "#### Downloading apache-flume: ${FLUME_TAR}... ####"
-	curl -s -o ${FLUME_TAR} ${ARTIFACT_FLUME_URL}/${FLUME_TAR}
-	if [[ $? -ne 0 ]]; then
-			_logError "cannot download apache-flume.tar.gz (${FLUME_TAR}) from ${ARTIFACT_FLUME_URL}"
-			return 1
-		else
-			_logOk ".............. Done! .............."
-		fi
+    _log "#### The version of the component is (${FLUME_TAR}) ####"
+    _log "#### Downloading apache-flume: ${FLUME_TAR}... ####"
+    curl -s -o ${FLUME_TAR} ${ARTIFACT_FLUME_URL}/${FLUME_TAR}
+    if [[ $? -ne 0 ]]; then
+        _logError "cannot download apache-flume.tar.gz (${FLUME_TAR}) from ${ARTIFACT_FLUME_URL}"
+        return 1
+    else
+        _logOk ".............. Done! .............."
+    fi
 
-	_log "#### Uncompresing apache-flume: ${FLUME_TAR}... ####"
-	tar xvzf ${FLUME_TAR} &> /dev/null
-	if [[ $? -ne 0 ]]; then
-		_logError ".............. Cannot untar flume.tar.gz (${FLUME_TAR}) .............."
-		return 1
-	else
-		_logOk ".............. Done! .............."
-	fi
+    _log "#### Uncompresing apache-flume: ${FLUME_TAR}... ####"
+    tar xvzf ${FLUME_TAR} &> /dev/null
+    if [[ $? -ne 0 ]]; then
+        _logError ".............. Cannot untar flume.tar.gz (${FLUME_TAR}) .............."
+        return 1
+    else
+        _logOk ".............. Done! .............."
+    fi
 
-	_log "### Download libthrift patch... ###"
-	ARTIFACT_LIBTHRIFT_URL="http://repo1.maven.org/maven2/org/apache/thrift/libthrift/0.9.1/"
-	LIBTHRIFT_JAR=libthrift-0.9.1.jar 
-	curl -s -o ${LIBTHRIFT_JAR} ${ARTIFACT_LIBTHRIFT_URL}/${LIBTHRIFT_JAR}
-	if [[ $? -ne 0 ]]; then
-			_logError "cannot download libthrift jar (${LIBTHRIFT_JAR}) from ${ARTIFACT_LIBTHRIFT_URL}"
-			return 1
-		else
-			_logOk ".............. Done! .............."
-		fi
-	rm -f ${FLUME_WO_TAR}/lib/libthrift-*.jar
-	mv ${LIBTHRIFT_JAR} ${FLUME_WO_TAR}/lib
+    _log "### Download libthrift patch... ###"
+    ARTIFACT_LIBTHRIFT_URL="http://repo1.maven.org/maven2/org/apache/thrift/libthrift/0.9.1/"
+    LIBTHRIFT_JAR=libthrift-0.9.1.jar 
+    curl -s -o ${LIBTHRIFT_JAR} ${ARTIFACT_LIBTHRIFT_URL}/${LIBTHRIFT_JAR}
+    if [[ $? -ne 0 ]]; then
+        _logError "cannot download libthrift jar (${LIBTHRIFT_JAR}) from ${ARTIFACT_LIBTHRIFT_URL}"
+        return 1
+    else
+        _logOk ".............. Done! .............."
+    fi
+    rm -f ${FLUME_WO_TAR}/lib/libthrift-*.jar
+    mv ${LIBTHRIFT_JAR} ${FLUME_WO_TAR}/lib
 
-	_log "#### Cleaning the temporal folders... ####"
-	rm -rf ${RPM_SOURCE_DIR}/${FLUME_WO_TAR}
-	rm -rf ${FLUME_WO_TAR}/docs # erase flume documentation
-        rm ${FLUME_WO_TAR}/conf/flume-conf.properties.template # we will add our own templates
-	rm -rf ${RPM_PRODUCT_SOURCE_DIR}
-	mkdir -p ${RPM_PRODUCT_SOURCE_DIR}
-	cp -R ${FLUME_WO_TAR}/* ${RPM_PRODUCT_SOURCE_DIR}/
-	popd &> /dev/null
-	rm -rf ${TMP_DIR}
-	return 0
+    _log "#### Cleaning the temporal folders... ####"
+    rm -rf ${RPM_SOURCE_DIR}/${FLUME_WO_TAR}
+    rm -rf ${FLUME_WO_TAR}/docs # erase flume documentation
+    rm ${FLUME_WO_TAR}/conf/flume-conf.properties.template # we will add our own templates
+    rm -rf ${RPM_PRODUCT_SOURCE_DIR}
+    mkdir -p ${RPM_PRODUCT_SOURCE_DIR}
+    cp -R ${FLUME_WO_TAR}/* ${RPM_PRODUCT_SOURCE_DIR}/
+    popd &> /dev/null
+    rm -rf ${TMP_DIR}
+    return 0
 
-	_logStage "######## The apache-flume is ready for use! ... ########"
+    _logStage "######## The apache-flume is ready for use! ... ########"
 }
 
 function copy_cygnus_startup_script(){
-        _logStage "######## Copying the cygnus startup script into the apache-flume... ########"
-        rm ${RPM_PRODUCT_SOURCE_DIR}/bin/flume-ng
-        cp $BASE_DIR/target/classes/cygnus-flume-ng ${RPM_PRODUCT_SOURCE_DIR}/bin
+    _logStage "######## Copying the cygnus startup script into the apache-flume... ########"
+    rm ${RPM_PRODUCT_SOURCE_DIR}/bin/flume-ng
+    cp $BASE_DIR/target/classes/cygnus-flume-ng ${RPM_PRODUCT_SOURCE_DIR}/bin
 }
 
 function copy_cygnus_to_flume(){
-	_logStage "######## Copying the cygnus jar into the apache-flume... ########"
-	mkdir -p ${RPM_PRODUCT_SOURCE_DIR}/plugins.d/cygnus
-	mkdir ${RPM_PRODUCT_SOURCE_DIR}/plugins.d/cygnus/lib
-	mkdir ${RPM_PRODUCT_SOURCE_DIR}/plugins.d/cygnus/libext
-	cp $BASE_DIR/target/cygnus-${PRODUCT_VERSION}-jar-with-dependencies.jar ${RPM_PRODUCT_SOURCE_DIR}/plugins.d/cygnus/lib
+    _logStage "######## Copying the cygnus jar into the apache-flume... ########"
+    mkdir -p ${RPM_PRODUCT_SOURCE_DIR}/plugins.d/cygnus
+    mkdir ${RPM_PRODUCT_SOURCE_DIR}/plugins.d/cygnus/lib
+    mkdir ${RPM_PRODUCT_SOURCE_DIR}/plugins.d/cygnus/libext
+    cp $BASE_DIR/target/cygnus-${PRODUCT_VERSION}-jar-with-dependencies.jar ${RPM_PRODUCT_SOURCE_DIR}/plugins.d/cygnus/lib
 }
 
 function copy_cygnus_conf() {
-	_logStage "######## Copying cygnus template config files to destination config directory... ########"
-	rm -rf {RPM_SOURCE_DIR}/config 
-	mkdir -p ${RPM_SOURCE_DIR}/config
-        cp ${BASE_DIR}/conf/* ${RPM_SOURCE_DIR}/config/
+    _logStage "######## Copying cygnus template config files to destination config directory... ########"
+    rm -rf {RPM_SOURCE_DIR}/config 
+    mkdir -p ${RPM_SOURCE_DIR}/config
+    cp ${BASE_DIR}/conf/* ${RPM_SOURCE_DIR}/config/
 }
 
 function clean_up_previous_builds() {
-	_logStage "######## Cleaning up previous builds of rpm... ########"
-
-	rm -rf ${RPM_BASE_DIR}/{RPMS,BUILDROOT,BUILD,SRPMS}
-	rm -rf ${RPM_SOURCE_DIR}/{config,usr}
-	return 0
+    _logStage "######## Cleaning up previous builds of rpm... ########"
+    rm -rf ${RPM_BASE_DIR}/{RPMS,BUILDROOT,BUILD,SRPMS}
+    rm -rf ${RPM_SOURCE_DIR}/{config,usr}
+    return 0
 }
 
 function usage() {

--- a/flume/neore/scripts/package.sh
+++ b/flume/neore/scripts/package.sh
@@ -70,6 +70,7 @@ function download_flume(){
 	_log "#### Cleaning the temporal folders... ####"
 	rm -rf ${RPM_SOURCE_DIR}/${FLUME_WO_TAR}
 	rm -rf ${FLUME_WO_TAR}/docs # erase flume documentation
+        rm ${FLUME_WO_TAR}/conf/flume-conf.properties.template # we will add our own templates
 	rm -rf ${RPM_PRODUCT_SOURCE_DIR}
 	mkdir -p ${RPM_PRODUCT_SOURCE_DIR}
 	cp -R ${FLUME_WO_TAR}/* ${RPM_PRODUCT_SOURCE_DIR}/
@@ -98,14 +99,7 @@ function copy_cygnus_conf() {
 	_logStage "######## Copying cygnus template config files to destination config directory... ########"
 	rm -rf {RPM_SOURCE_DIR}/config 
 	mkdir -p ${RPM_SOURCE_DIR}/config
-	for file in $(ls ${BASE_DIR}/conf)
-	do
-		# file=$(basename ${file})
-		# renamed_file=${file%.template}
-		# cp ${BASE_DIR}/conf/${file} ${RPM_SOURCE_DIR}/config/${renamed_file}
-
-		cp ${BASE_DIR}/conf/${file} ${RPM_SOURCE_DIR}/config/
-	done
+        cp ${BASE_DIR}/conf/* ${RPM_SOURCE_DIR}/config/
 }
 
 function clean_up_previous_builds() {


### PR DESCRIPTION
* Fixes issue https://github.com/telefonicaid/fiware-connectors/issues/348
* Unit tests not required
* (unofficial) e2e tests:

```
$ sudo rpm -i neore/rpm/RPMS/x86_64/cygnus-0.7.1-%\{_product_release\}.x86_64.rpm 
[INFO] Creating cygnus user
[INFO] Creating log directory
Done
$ ls /usr/cygnus/conf/
agent.conf.template  cygnus_instance.conf.template  krb5.conf.template  log4j.properties           matching_table.conf.template
agent_test.conf      flume-env.sh.template          krb5_login.conf     log4j.properties.template  README.md
```
* Assignee @vgarciag but LGTM from @fgalan and @gtorodelvalle is also required